### PR TITLE
Feature/UPPSF-858 Implement time constraint for /notify

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -37,7 +37,10 @@ paths:
         - name: lastChangeDate
           in: query
           required: true
-          description: Timestamp of the change which generated this notification. The timestamp is formatted according to ISO 8601
+          description: |
+            Timestamp of the change which generated this notification.
+            It has an upper limit and requests with timestamps prior to that limit are discarded with status 400 BadRequest.
+            It should be formatted according to ISO 8601.
           type: string
           format: date-time
       responses:

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 }
 
 func waitForSignal() {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 }

--- a/notifier/handlers.go
+++ b/notifier/handlers.go
@@ -2,9 +2,9 @@ package notifier
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
-
 	"time"
 
 	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
@@ -13,8 +13,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// TimeFormat is the format used to read time values from request parameters
+const TimeFormat = "2006-01-02T15:04:05Z"
+
 // maxTimeValue represents the maximum useful time value (for comparisons like finding the minimum value in a range of times)
 var maxTimeValue = time.Unix(1<<63-62135596801, 999999999)
+
+// LastChangeLimit represents the upper limit to how far in the past we can reingest smartlogic updates
+var LastChangeLimit = time.Hour * 168
 
 type Handler struct {
 	notifier  Servicer
@@ -71,12 +77,20 @@ func (h *Handler) HandleNotify(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	lastChange, err := time.Parse("2006-01-02T15:04:05Z", lastChangeDate)
+	lastChange, err := time.Parse(TimeFormat, lastChangeDate)
+	if err != nil {
+		writeResponseMessage(resp,
+			http.StatusBadRequest,
+			"application/json",
+			fmt.Sprintf("{\"message\": \"Date is not in the format %s\"}", TimeFormat))
+		return
+	}
 	log.WithField("time", lastChange).Debug("Parsing notification time")
 	lastChange = lastChange.Add(-10 * time.Millisecond)
 	log.WithField("time", lastChange).Debug("Subtracting notification time wobble")
-	if err != nil {
-		writeResponseMessage(resp, http.StatusBadRequest, "application/json", `{"message": "Date is not in the format 2006-01-02T15:04:05.000Z"}`)
+
+	if time.Since(lastChange) > LastChangeLimit {
+		writeJSONResponseMessage(resp, http.StatusBadRequest, fmt.Sprintf("Last change date should be time point in the last %.0f hours", LastChangeLimit.Hours()))
 		return
 	}
 


### PR DESCRIPTION
Add time constraint for `lastChangeData` parameter for `/notify` endpoint so that no queries to Smartlogic for period longer than one week from the current date and time should be possible.