### PR TITLE
Feature/uppsf 1309 history req

### DIFF
--- a/smartlogic/client_test.go
+++ b/smartlogic/client_test.go
@@ -240,3 +240,21 @@ func TestClient_GetChangedConceptList_BadResponseBody(t *testing.T) {
 	assert.IsType(t, &json.SyntaxError{}, err)
 	assert.Empty(t, response)
 }
+
+func TestClient_buildChangesAPIQueryParams(t *testing.T) {
+	changeDate, err := time.Parse(slTimeFormat, "2020-04-27T00:00:00.000Z")
+	assert.NoError(t, err)
+
+	client, err := NewSmartlogicTestClient(&mockHttpClient{}, "http://base/url", "modelName", "apiKey", "conceptUriPrefix")
+	assert.NoError(t, err)
+
+	queryParams := client.buildChangesAPIQueryParams(changeDate)
+	assert.Contains(t, queryParams, "path")
+	assert.Equal(t, queryParams.Get("path"), "tchmodel:modelName/teamwork:Change/rdf:instance")
+
+	assert.Contains(t, queryParams, "properties")
+	assert.Equal(t, queryParams.Get("properties"), "sem:about")
+
+	assert.Contains(t, queryParams, "filters")
+	assert.Equal(t, queryParams.Get("filters"), "subject(sem:committed>\"2020-04-27T00:00:00.000Z\"^^xsd:dateTime)")
+}

--- a/smartlogic/http_mock_test.go
+++ b/smartlogic/http_mock_test.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 )
 
-type mockHttpClient struct {
+type mockHTTPClient struct {
 	resp       string
 	statusCode int
 	err        error
 }
 
-func (c mockHttpClient) Do(req *http.Request) (resp *http.Response, err error) {
+func (c mockHTTPClient) Do(req *http.Request) (resp *http.Response, err error) {
 	cb := ioutil.NopCloser(bytes.NewReader([]byte(c.resp)))
 	return &http.Response{Body: cb, StatusCode: c.statusCode}, c.err
 }


### PR DESCRIPTION
We call specific Smartlogic REST API to fetch the changes since specified time. However recently that endpoint proves to show worse results in terms of response time.
We are changing the API that we are using via changing the query params of the request (as we are specifying the endpoint in the `path` query param). The new call allows us to from the whole changes object to fetch only the things we are interested in. These are the uuid of the changed concepts.