### PR TITLE
Smartlogic timing issue workaround 

### DIFF
--- a/notifier/service.go
+++ b/notifier/service.go
@@ -44,6 +44,17 @@ func (s *Service) Notify(lastChange time.Time, transactionID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch the list of changed concepts: %w", err)
 	}
+
+	if len(changedConcepts) == 0 {
+		// After some time interval retry getting the changed concept list,
+		// because Smartlogic could have notified us before the data is available to be retrieved.
+		time.Sleep(time.Second * 5)
+		changedConcepts, err = s.smartlogic.GetChangedConceptList(lastChange)
+		if err != nil {
+			return fmt.Errorf("failed while retrying to fetch the list of changed concepts: %w", err)
+		}
+	}
+
 	if len(changedConcepts) == 0 {
 		return fmt.Errorf("no changed concepts since %v were returned for transaction id %s", lastChange, transactionID)
 	}

--- a/notifier/service.go
+++ b/notifier/service.go
@@ -47,7 +47,7 @@ func (s *Service) Notify(lastChange time.Time, transactionID string) error {
 
 	if len(changedConcepts) == 0 {
 		// After some time interval retry getting the changed concept list,
-		// because Smartlogic could have notified us before the data is available to be retrieved.
+		// because Smartlogic sometimes notify us before the data is available to be retrieved.
 		time.Sleep(time.Second * 5)
 		changedConcepts, err = s.smartlogic.GetChangedConceptList(lastChange)
 		if err != nil {

--- a/notifier/service_test.go
+++ b/notifier/service_test.go
@@ -54,6 +54,32 @@ func TestService_Notify(t *testing.T) {
 	assert.Equal(t, 1, kc.sentCount)
 }
 
+func TestService_RetryNotify(t *testing.T) {
+	var isGetFuncCalled bool
+	kc := &mockKafkaClient{}
+	sl := &mockSmartlogicClient{
+		concepts: map[string]string{
+			"uuid1": "concept1",
+			"uuid2": "concept2",
+		},
+		getChangedConceptListFunc: func(changeDate time.Time) ([]string, error) {
+			if isGetFuncCalled {
+				return []string{"uuid2"}, nil
+			}
+
+			isGetFuncCalled = true
+			return []string{}, nil
+		},
+	}
+
+	service := NewNotifierService(kc, sl)
+
+	err := service.Notify(time.Now(), "transactionID")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, kc.sentCount)
+}
+
 func TestService_ForceNotify(t *testing.T) {
 	kc := &mockKafkaClient{}
 	sl := &mockSmartlogicClient{


### PR DESCRIPTION
# Description

## What

Add retry attempt for getting changes from Smartlogic for the case in which we were notified but it seemed like there are no changes. The retry will be performed once after a period of 5 seconds.

## Why

Smartlogic notifies our service before they make the changes on their side visible to the outside world.  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
