### PR TITLE
Return 400 if query params are incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-Entrypoint for concept publish notifications from the Smartlogic Semaphore system
+Entrypoint for concept publish notifications from the Smartlogic Semaphore system.
 
 ## Installation
 

--- a/api.yml
+++ b/api.yml
@@ -32,7 +32,7 @@ paths:
         - name: affectedGraphId
           in: query
           required: true
-          description: ID of a model which generated the notification.  In normal use, will be the same as modifiedGraphId.
+          description: ID of the model which generated the notification. In normal use, will be the same as modifiedGraphId.
           type: string
         - name: lastChangeDate
           in: query

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	smartlogicAPIKey := app.String(cli.StringOpt{
 		Name:   "smartlogicAPIKey",
-		Desc:   "Smartlogic model to read from",
+		Desc:   "Smartlogic API key",
 		EnvVar: "SMARTLOGIC_API_KEY",
 	})
 
@@ -157,14 +157,14 @@ func main() {
 		}
 
 		httpClient := getResilientClient(smartlogicTimeoutDuration)
-		sl, err := smartlogic.NewSmartlogicClient(httpClient, *smartlogicBaseURL, *smartlogicModel, *smartlogicAPIKey, *conceptUriPrefix)
+		slClient, err := smartlogic.NewSmartlogicClient(httpClient, *smartlogicBaseURL, *smartlogicModel, *smartlogicAPIKey, *conceptUriPrefix)
 		if err != nil {
 			log.Error("Error generating access token when connecting to Smartlogic.  If this continues to fail, please check the configuration.")
 		}
 
-		service := notifier.NewNotifierService(kf, sl)
+		service := notifier.NewNotifierService(kf, slClient)
 
-		handler := notifier.NewNotifierHandler(service)
+		handler := notifier.NewNotifierHandler(service, *smartlogicModel)
 		handler.RegisterEndpoints(router)
 
 		healthServiceConfig := &notifier.HealthServiceConfig{

--- a/notifier/handlers.go
+++ b/notifier/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -62,26 +63,12 @@ func WithTicker(t Ticker) func(*Handler) {
 
 func (h *Handler) HandleNotify(resp http.ResponseWriter, req *http.Request) {
 	vars := req.URL.Query()
-	var notSet []string
-	modifiedGraphId := vars.Get("modifiedGraphId")
-	if modifiedGraphId == "" || modifiedGraphId != h.model {
-		notSet = append(notSet, "modifiedGraphId")
-	}
-	affectedGraphId := vars.Get("affectedGraphId")
-	if affectedGraphId == "" || affectedGraphId != h.model {
-		notSet = append(notSet, "affectedGraphId")
-	}
-	lastChangeDate := vars.Get("lastChangeDate")
-	if lastChangeDate == "" {
-		notSet = append(notSet, "lastChangeDate")
-	}
-
-	if len(notSet) > 0 {
-		writeJSONResponseMessage(resp, http.StatusBadRequest, responseData{Msg: `Query parameters are missing or incorrect: ` + strings.Join(notSet, ", ")})
+	err := validateQueryParams(h.model, &vars)
+	if err != nil {
+		writeJSONResponseMessage(resp, http.StatusBadRequest, responseData{Msg: err.Error()})
 		return
 	}
-
-	lastChange, err := validateLastChangeDate(lastChangeDate)
+	lastChange, err := validateLastChangeDate(vars.Get("lastChangeDate"))
 	if err != nil {
 		writeJSONResponseMessage(resp, http.StatusBadRequest, responseData{Msg: err.Error()})
 		return
@@ -93,7 +80,6 @@ func (h *Handler) HandleNotify(resp http.ResponseWriter, req *http.Request) {
 			transactionID: transactionID,
 		}
 	}()
-
 	writeJSONResponseMessage(resp, http.StatusOK, responseData{Msg: "Concepts successfully ingested"})
 }
 
@@ -268,4 +254,24 @@ func validateLastChangeDate(change string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("Last change date should be time point in the last %.0f hours", LastChangeLimit.Hours())
 	}
 	return lastChange, nil
+}
+
+func validateQueryParams(model string, vars *url.Values) error {
+	var notSet []string
+	modifiedGraphID := vars.Get("modifiedGraphId")
+	if modifiedGraphID == "" || modifiedGraphID != model {
+		notSet = append(notSet, "modifiedGraphId")
+	}
+	affectedGraphID := vars.Get("affectedGraphId")
+	if affectedGraphID == "" || affectedGraphID != model {
+		notSet = append(notSet, "affectedGraphId")
+	}
+	lastChangeDate := vars.Get("lastChangeDate")
+	if lastChangeDate == "" {
+		notSet = append(notSet, "lastChangeDate")
+	}
+	if len(notSet) > 0 {
+		return errors.New("Query parameters are missing or incorrect: " + strings.Join(notSet, ", "))
+	}
+	return nil
 }

--- a/notifier/handlers_test.go
+++ b/notifier/handlers_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	http "net/http"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -15,6 +15,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+const smartlogicModel = "FTTestModel"
 
 func TestHandlers(t *testing.T) {
 	t.Parallel()
@@ -34,7 +36,7 @@ func TestHandlers(t *testing.T) {
 		{
 			name:       "Notify - Success",
 			method:     "GET",
-			url:        fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s", today),
+			url:        fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s", smartlogicModel, smartlogicModel, today),
 			resultBody: "{\"message\": \"Concepts successfully ingested\"}",
 			resultCode: 200,
 			mockService: &mockService{
@@ -46,9 +48,9 @@ func TestHandlers(t *testing.T) {
 		{
 			name:        "Notify - Missing query parameters",
 			method:      "GET",
-			url:         "/notify?modifiedGraphId=2&lastChangeDate=2017-05-31T13:00:00.000Z",
+			url:         fmt.Sprintf("/notify?modifiedGraphId=%s&lastChangeDate=2017-05-31T13:00:00.000Z", smartlogicModel),
 			resultCode:  400,
-			resultBody:  "{\"message\": \"Query parameters were not set: affectedGraphId\"}",
+			resultBody:  "{\"message\": \"Query parameters are missing or incorrect: affectedGraphId\"}",
 			mockService: &mockService{},
 		},
 		{
@@ -56,13 +58,21 @@ func TestHandlers(t *testing.T) {
 			method:      "GET",
 			url:         "/notify",
 			resultCode:  400,
-			resultBody:  "{\"message\": \"Query parameters were not set: modifiedGraphId, affectedGraphId, lastChangeDate\"}",
+			resultBody:  "{\"message\": \"Query parameters are missing or incorrect: modifiedGraphId, affectedGraphId, lastChangeDate\"}",
+			mockService: &mockService{},
+		},
+		{
+			name:        "Notify - Incorrect modifiedGraphId and affectedGraphId",
+			method:      "GET",
+			url:         fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s", today),
+			resultCode:  400,
+			resultBody:  "{\"message\": \"Query parameters are missing or incorrect: modifiedGraphId, affectedGraphId\"}",
 			mockService: &mockService{},
 		},
 		{
 			name:        "Notify - Bad query parameters ",
 			method:      "GET",
-			url:         "/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=notadate",
+			url:         fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s", smartlogicModel, smartlogicModel, "nodate"),
 			resultCode:  400,
 			resultBody:  "{\"message\": \"Date is not in the format 2006-01-02T15:04:05Z\"}",
 			mockService: &mockService{},
@@ -70,7 +80,7 @@ func TestHandlers(t *testing.T) {
 		{
 			name:        "Notify - Bad lastChangeDate parameter",
 			method:      "GET",
-			url:         fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s", past),
+			url:         fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s", smartlogicModel, smartlogicModel, past),
 			resultCode:  400,
 			resultBody:  fmt.Sprintf("{\"message\": \"Last change date should be time point in the last %.0f hours\"}", LastChangeLimit.Hours()),
 			mockService: &mockService{},
@@ -78,7 +88,7 @@ func TestHandlers(t *testing.T) {
 		{
 			name:       "Notify - Error",
 			method:     "GET",
-			url:        fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s", today),
+			url:        fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s", smartlogicModel, smartlogicModel, today),
 			resultBody: "{\"message\": \"Concepts successfully ingested\"}",
 			resultCode: 200,
 			mockService: &mockService{
@@ -234,7 +244,7 @@ func TestHandlers(t *testing.T) {
 
 	for _, d := range testCases {
 		t.Run(d.name, func(t *testing.T) {
-			handler := NewNotifierHandler(d.mockService)
+			handler := NewNotifierHandler(d.mockService, smartlogicModel)
 			m := mux.NewRouter()
 			handler.RegisterEndpoints(m)
 
@@ -330,14 +340,14 @@ func TestConcurrentNotify(t *testing.T) {
 			tickerInterval := test.duration / 2
 			tk := &ticker{ticker: time.NewTicker(tickerInterval)}
 
-			handler := NewNotifierHandler(service, WithTicker(tk))
+			handler := NewNotifierHandler(service, smartlogicModel, WithTicker(tk))
 
 			m := mux.NewRouter()
 			handler.RegisterEndpoints(m)
 
 			var reqs []*http.Request
 			for _, tPoint := range test.notificationTimes {
-				url := fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s%s", today, tPoint)
+				url := fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s%s", smartlogicModel, smartlogicModel, today, tPoint)
 				req, _ := http.NewRequest("GET", url, nil)
 				reqs = append(reqs, req)
 			}
@@ -457,14 +467,14 @@ func TestProcessingNotifyRequestsDoesNotBlock(t *testing.T) {
 			tickerInterval := test.duration / 10
 			tk := &mockTicker{ticker: time.NewTicker(tickerInterval)}
 
-			handler := NewNotifierHandler(service, WithTicker(tk))
+			handler := NewNotifierHandler(service, smartlogicModel, WithTicker(tk))
 
 			m := mux.NewRouter()
 			handler.RegisterEndpoints(m)
 
 			var reqs []*http.Request
 			for _, tPoint := range test.notificationTimes {
-				url := fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s%s", today, tPoint)
+				url := fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s%s", smartlogicModel, smartlogicModel, today, tPoint)
 				req, _ := http.NewRequest("GET", url, nil)
 				reqs = append(reqs, req)
 			}
@@ -503,7 +513,7 @@ func TestGettingSmartlogicChangesOneRequestAtATime(t *testing.T) {
 		},
 	}
 	today := time.Now().Format(TimeFormat)
-	requestURI := fmt.Sprintf("/notify?affectedGraphId=1&modifiedGraphId=2&lastChangeDate=%s", today)
+	requestURI := fmt.Sprintf("/notify?affectedGraphId=%s&modifiedGraphId=%s&lastChangeDate=%s", smartlogicModel, smartlogicModel, today)
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			kc := &mockKafkaClient{}
@@ -522,7 +532,7 @@ func TestGettingSmartlogicChangesOneRequestAtATime(t *testing.T) {
 			tickerInterval := test.duration / 5
 			tk := &ticker{ticker: time.NewTicker(tickerInterval)}
 
-			handler := NewNotifierHandler(service, WithTicker(tk))
+			handler := NewNotifierHandler(service, smartlogicModel, WithTicker(tk))
 
 			m := mux.NewRouter()
 			handler.RegisterEndpoints(m)

--- a/notifier/healthcheck.go
+++ b/notifier/healthcheck.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Financial-Times/service-status-go/gtg"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
 	"github.com/gorilla/mux"
-	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/notifier/service.go
+++ b/notifier/service.go
@@ -20,27 +20,27 @@ type Servicer interface {
 }
 
 type Service struct {
-	kafka      kafka.Producer
-	smartlogic smartlogic.Clienter
+	kafka    kafka.Producer
+	slClient smartlogic.Clienter
 }
 
-func NewNotifierService(kafka kafka.Producer, smartlogic smartlogic.Clienter) Servicer {
+func NewNotifierService(kafka kafka.Producer, slClient smartlogic.Clienter) *Service {
 	return &Service{
-		kafka:      kafka,
-		smartlogic: smartlogic,
+		kafka:    kafka,
+		slClient: slClient,
 	}
 }
 
 func (s *Service) GetConcept(uuid string) ([]byte, error) {
-	return s.smartlogic.GetConcept(uuid)
+	return s.slClient.GetConcept(uuid)
 }
 
 func (s *Service) GetChangedConceptList(lastChange time.Time) (uuids []string, err error) {
-	return s.smartlogic.GetChangedConceptList(lastChange)
+	return s.slClient.GetChangedConceptList(lastChange)
 }
 
 func (s *Service) Notify(lastChange time.Time, transactionID string) error {
-	changedConcepts, err := s.smartlogic.GetChangedConceptList(lastChange)
+	changedConcepts, err := s.slClient.GetChangedConceptList(lastChange)
 	if err != nil {
 		return fmt.Errorf("failed to fetch the list of changed concepts: %w", err)
 	}
@@ -55,7 +55,7 @@ func (s *Service) ForceNotify(UUIDs []string, transactionID string) error {
 	errorMap := map[string]error{}
 
 	for _, conceptUUID := range UUIDs {
-		concept, err := s.smartlogic.GetConcept(conceptUUID)
+		concept, err := s.slClient.GetConcept(conceptUUID)
 		if err != nil {
 			errorMap[conceptUUID] = err
 			continue


### PR DESCRIPTION
# Description

## What

This PR provides a fix for the case in which the `modifiedGraphId` or `affectedGraphId` parameters are incorrect, i.e. don't contain FTStagingModel or FTProductionModel.

## Why

We received test requests from API Gateway which resulted in calling SL when there was no need to do so.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
