### PR TITLE
Error logging extension

### DIFF
--- a/smartlogic/client.go
+++ b/smartlogic/client.go
@@ -102,7 +102,9 @@ func (c *Client) GetConcept(uuid string) ([]byte, error) {
 	// we additionally validate the response in order to check whether the response is for existing concept.
 	ok, err := c.isExistingConcept(body)
 	if err != nil {
-		return nil, fmt.Errorf("invalid concept representation returned for uuid %v", uuid)
+		errorMsg := fmt.Errorf("invalid concept representation returned for uuid %v", uuid)
+		entry.WithError(err).Error(errorMsg)
+		return nil, errorMsg
 	}
 	if !ok {
 		return nil, ErrorConceptDoesNotExist

--- a/smartlogic/client.go
+++ b/smartlogic/client.go
@@ -103,7 +103,7 @@ func (c *Client) GetConcept(uuid string) ([]byte, error) {
 	ok, err := c.isExistingConcept(body)
 	if err != nil {
 		errorMsg := fmt.Errorf("invalid concept representation returned for uuid %v", uuid)
-		entry.WithError(err).Error(errorMsg)
+		entry.WithError(err).WithField("body", string(body)).Error(errorMsg)
 		return nil, errorMsg
 	}
 	if !ok {


### PR DESCRIPTION
# Description

## What

Extension of error logging in smartlogic-notifier 

## Why

When smartlogic-notifier service fails with invalid concept representation returned for uuid, we don't log the underlining error and don't have visibility on why exactly did it fail.

This is relevant, because smartlogic-notifier experiences sporadic healtcheck failures with invalid concept representation returned for uuid error.

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
